### PR TITLE
12 build via GitHub actions

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths: # only run if firmware changes
       - 'firmware/**'
-      - '.github/workflows/**'
+      - '.github/workflows/firmware.yml'
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware
-          path: ./firmware/esp32/gdoor/.pio/build/GDOOR_ESP32MINI
+          name: gdoor_firmware
+          path: ./firmware/esp32/gdoor/.pio/build/GDOOR_ESP32MINI/*.bin

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: firmware
-          path: .pio/build/GDOOR_ESP32MINI
+          path: ./firmware/esp32/gdoor/.pio/build/GDOOR_ESP32MINI

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,9 @@
 name: PlatformIO CI
 
-on: [push]
+on: 
+  push:
+    paths:
+      - 'firmware/**' # only run if firmware changes
 
 jobs:
   build:
@@ -22,6 +25,10 @@ jobs:
           python-version: '3.12'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
-
       - name: Build PlatformIO Project
         run: pio run
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: .pio/build/GDOOR_ESP32MINI

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,27 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./firmware/esp32/gdoor
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,8 +10,8 @@ jobs:
         working-directory: ./firmware/esp32/gdoor
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-pio
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,8 +2,9 @@ name: PlatformIO CI
 
 on: 
   push:
-    paths:
-      - 'firmware/**' # only run if firmware changes
+    paths: # only run if firmware changes
+      - 'firmware/**'
+      - '.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
This adds a basic GitHub Action to build the firmware when
- pushing to the repo (all branches, but could be limited to pull requests only)
- if the firmware files were modified (e.g. editing the docs won't trigger a firmware build)